### PR TITLE
Remove errno usage in `mxml_fd_read()`

### DIFF
--- a/mxml-file.c
+++ b/mxml-file.c
@@ -1003,7 +1003,7 @@ mxml_fd_read(_mxml_fdbuf_t *buf)		/* I - File descriptor buffer */
     if (errno != EAGAIN && errno != EINTR)
 #else
     if (errno != EAGAIN)
-#endif // EINTR
+#endif /* EINTR */
       return (-1);
 #endif
   if (bytes == 0)

--- a/mxml-file.c
+++ b/mxml-file.c
@@ -998,13 +998,14 @@ mxml_fd_read(_mxml_fdbuf_t *buf)		/* I - File descriptor buffer */
   */
 
   while ((bytes = (int)read(buf->fd, buf->buffer, sizeof(buf->buffer))) < 0)
+#ifndef __PRX_BUILD__
 #ifdef EINTR
     if (errno != EAGAIN && errno != EINTR)
 #else
     if (errno != EAGAIN)
-#endif /* EINTR */
+#endif // EINTR
       return (-1);
-
+#endif
   if (bytes == 0)
     return (-1);
 

--- a/ps4/Makefile
+++ b/ps4/Makefile
@@ -8,6 +8,10 @@ ifeq ($(strip $(OO_PS4_TOOLCHAIN)),)
 $(error "Please set OO_PS4_TOOLCHAIN in your environment. export OO_PS4_TOOLCHAIN=<path>")
 endif
 
+ifeq ($(PRX_BUILD),1)
+EXTRAFLAGS = -D__PRX_BUILD__
+endif
+
 include $(OO_PS4_TOOLCHAIN)/build_rules.mk
 
 #---------------------------------------------------------------------------------
@@ -35,7 +39,7 @@ INCLUDE		:=	./
 DATA		:=	data
 LIBS		:=	 
 
-CFLAGS      += -cc1 -triple x86_64-pc-freebsd-elf -munwind-tables -emit-obj -isysroot $(OO_PS4_TOOLCHAIN) -isystem $(OO_PS4_TOOLCHAIN)/include $(INCLUDES) -DMZ_PLATFORM=PS4
+CFLAGS      += -cc1 -triple x86_64-pc-freebsd-elf -munwind-tables -emit-obj -isysroot $(OO_PS4_TOOLCHAIN) -isystem $(OO_PS4_TOOLCHAIN)/include $(INCLUDES) -DMZ_PLATFORM=PS4 $(EXTRAFLAGS)
 CXXFLAGS    += $(CFLAGS) -isystem $(OO_PS4_TOOLCHAIN)/include/c++/v1
 
 ifneq ($(BUILD),$(notdir $(CURDIR)))


### PR DESCRIPTION
Building as PRX gives this error
```
ld.lld: error: undefined symbol: __errno_location
>>> referenced by mxml-file.c
>>>               mxml-file.o:(mxml_fd_read) in archive /mnt/c/ps4/oosdk/OpenOrbis/PS4Toolchain/lib/libmxml.a
>>> referenced by mxml-file.c
>>>               mxml-file.o:(mxml_fd_read) in archive /mnt/c/ps4/oosdk/OpenOrbis/PS4Toolchain/lib/libmxml.a
make: *** [Makefile:73: /mnt/c/ps4/GoldHEN_Plugins_Repository/plugin_src/game_patch/../../bin/plugins/prx_final/game_patch] Error 1
```